### PR TITLE
feat: add user schema and tests

### DIFF
--- a/app/schemas/user.py
+++ b/app/schemas/user.py
@@ -1,0 +1,28 @@
+from marshmallow import fields, validates, ValidationError
+from app import ma
+from app.models.user import User
+
+class UserSchema(ma.SQLAlchemySchema):
+    class Meta:
+        model = User
+        load_instance = True
+
+    id = ma.String(dump_only=True)
+    username = ma.String(required=True)
+    email = ma.Email(required=True)
+    password = ma.String(required=True, load_only=True)
+    created_at = ma.DateTime(dump_only=True)
+    is_active = ma.Boolean(dump_only=True)
+    role = ma.String(dump_only=True)
+
+    @validates('username')
+    def validate_username(self, value):
+        if len(value) < 3:
+            raise ValidationError('Username must be at least 3 characters long')
+        if len(value) > 80:
+            raise ValidationError('Username must be less than 80 characters')
+
+    @validates('password')
+    def validate_password(self, value):
+        if len(value) < 8:
+            raise ValidationError('Password must be at least 8 characters long')

--- a/tests/test_user_schema.py
+++ b/tests/test_user_schema.py
@@ -1,0 +1,90 @@
+import pytest
+from marshmallow import ValidationError
+from app.schemas.user import UserSchema
+from app.models.user import User
+
+def test_valid_user_serialization():
+    """
+    GIVEN a User instance
+    WHEN serializing with UserSchema
+    THEN check the serialization is correct
+    """
+    user = User(
+        username="testuser",
+        email="test@test.com"
+    )
+    user.set_password("password123")
+    
+    schema = UserSchema()
+    result = schema.dump(user)
+    
+    assert result['username'] == "testuser"
+    assert result['email'] == "test@test.com"
+    assert 'password' not in result  # Password should not be in serialized data
+    assert 'id' in result
+
+def test_user_deserialization():
+    """
+    GIVEN valid user data
+    WHEN deserializing with UserSchema
+    THEN check instance is created correctly
+    """
+    user_data = {
+        "username": "testuser",
+        "email": "test@test.com",
+        "password": "password123"
+    }
+    
+    schema = UserSchema()
+    user = schema.load(user_data)
+    
+    assert user.username == user_data['username']
+    assert user.email == user_data['email']
+
+def test_invalid_username():
+    """
+    GIVEN user data with invalid username
+    WHEN validating with UserSchema
+    THEN check validation error is raised
+    """
+    schema = UserSchema()
+    
+    with pytest.raises(ValidationError) as err:
+        schema.load({
+            "username": "ab",  # too short
+            "email": "test@test.com",
+            "password": "password123"
+        })
+    assert "username" in err.value.messages
+
+def test_invalid_email():
+    """
+    GIVEN user data with invalid email
+    WHEN validating with UserSchema
+    THEN check validation error is raised
+    """
+    schema = UserSchema()
+    
+    with pytest.raises(ValidationError) as err:
+        schema.load({
+            "username": "testuser",
+            "email": "invalid-email",
+            "password": "password123"
+        })
+    assert "email" in err.value.messages
+
+def test_invalid_password():
+    """
+    GIVEN user data with invalid password
+    WHEN validating with UserSchema
+    THEN check validation error is raised
+    """
+    schema = UserSchema()
+    
+    with pytest.raises(ValidationError) as err:
+        schema.load({
+            "username": "testuser",
+            "email": "test@test.com",
+            "password": "short"  # too short
+        })
+    assert "password" in err.value.messages


### PR DESCRIPTION
# User Schema Implementation

## Changes
- Add UserSchema for model serialization/deserialization
- Implement validation rules for user fields:
  - Username (3-80 characters)
  - Email (valid format)
  - Password (min 8 characters)
- Add comprehensive schema tests

## Tests Added
- [x] Valid user serialization
- [x] Valid user deserialization
- [x] Username validation
- [x] Email validation
- [x] Password validation
- [x] Field visibility (password hidden in output)

## How to Test
1. Run pytest:
```bash
pytest tests/test_user_schema.py -v